### PR TITLE
Append Y to ranger data frame to avoid namespace errors, add test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,7 @@ Imports:
     ranger,
     data.table,
     foreach
+Suggests:
+    MASS,
+    testthat
 RoxygenNote: 6.0.1

--- a/R/rf_opt.R
+++ b/R/rf_opt.R
@@ -46,23 +46,29 @@ rf_opt <- function(train_data,
                    acq = "ei",
                    kappa = 2.576,
                    eps = 0.0,
-                   kernel = list(type = "exponential", power = 2))
-{
+                   kernel = list(type = "exponential", power = 2)) {
+
   dtrain <- train_data
   dtest <- test_data
 
-  if (class(train_label) != "factor"){
+  if (class(train_label) != "factor") {
     trainlabel <- as.factor(train_label)
-  } else{
-    trainlabel <- train_label}
+  } else {
+    trainlabel <- train_label
+  }
 
-  if (class(test_label) != "factor"){
+  if (class(test_label) != "factor") {
     testlabel <- as.factor(train_label)
-  } else{
-    testlabel <- test_label}
+  } else {
+    testlabel <- test_label
+  }
+
+  # Ranger does not seem to support Y being a vector outside of the dataframe,
+  # so we explicitly add to dataframe with a unique name to avoid conflicts.
+  dtrain <- cbind(`_Y` = trainlabel, dtrain)
 
   rf_holdout <- function(num_trees_opt, mtry_opt) {
-    model <- ranger(trainlabel ~., dtrain, num.trees = num_trees_opt, mtry = mtry_opt)
+    model <- ranger(`_Y` ~., dtrain, num.trees = num_trees_opt, mtry = mtry_opt)
     t.pred <- predict(model, dat = dtest)
     Pred <- sum(diag(table(testlabel, t.pred$predictions)))/nrow(dtest)
     list(Score = Pred, Pred = Pred)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(MlBayesOpt)
+
+test_check("MlBayesOpt")

--- a/tests/testthat/test-rf_opt.R
+++ b/tests/testthat/test-rf_opt.R
@@ -1,0 +1,70 @@
+library(MlBayesOpt)
+library(testthat)
+
+context("rf_opt")
+
+set.seed(123)
+
+# Default example.
+# This will generate an error in GP_deviance()
+# "Infinite values of the Deviance Function, unable to find optimum parameters"
+mod <- rf_opt(
+  train_data = iris_train,
+  train_label = iris_train$Species,
+  test_data = iris_test,
+  test_label = iris_test$Species,
+  mtry_range = c(1L, 4L)
+)
+
+print(mod)
+
+########################################3
+# Boston test.
+data(Boston, package = "MASS")
+
+dim(Boston)
+
+# Divide into training, test, and holdout.
+# 50% into training, 20% into test, 30% into holdout.
+n = nrow(Boston)
+n_training = ceiling(n * 0.5)
+n_test = ceiling(n * 0.2)
+n_holdout = n - n_training - n_test
+c(n_training, n_test, n_holdout)
+
+# Create assignment pool.
+pool = c(rep(1, n_training), rep(2, n_test), rep(3, n_holdout))
+
+# Randomize.
+set.seed(1, "L'Ecuyer-CMRG")
+assignment = sample(pool)
+
+#y = Boston$medv
+y_bin = as.factor(Boston$medv > 23)
+y_gaus = Boston$medv
+y = y_bin
+
+# Remove outcome from covariate dataframe.
+x = Boston[, -14]
+# Convert to a matrix and remove intercept.
+x_mat = data.frame(model.matrix(~ ., data = x)[, -1])
+
+x_train = x_mat[pool == 1, ]
+x_test = x_mat[pool == 2, ]
+x_holdout = x_mat[pool == 3, ]
+
+y_train = y[pool == 1]
+y_test = y[pool == 2]
+y_holdout = y[pool == 3]
+
+set.seed(71)
+res1 <- rf_opt(train_data = x_train,
+               train_label = y_train,
+               test_data = x_test,
+               test_label = y_test,
+               mtry_range = c(1L, ncol(x_train)),
+               # Doesn't work:
+               #num_tree_range = c(500L, 500L)
+               num_tree_range = c(500L, 501L)
+)
+str(res1)


### PR DESCRIPTION
Hello,

This fixes the namespace bug I reported in rf_opt (#37). I don't know if there is a better way to work around this, but I've fixed the issue by cbinding Y onto the X dataframe. Ranger doesn't seem to work with Y as a separate vector.

I also added the RF example and a Boston example as minimal tests. The RF example runs into another error with GP_deviance() unfortunately.

Thanks,
Chris