### PR TITLE
RF: min node size

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,7 @@ Imports:
     ranger,
     data.table,
     foreach
+Suggests:
+    MASS,
+    testthat
 RoxygenNote: 6.0.1

--- a/R/rf_opt.R
+++ b/R/rf_opt.R
@@ -5,8 +5,11 @@
 ##' @param train_label The column of class to classify in the training data
 ##' @param test_data A data frame for training of xgboost
 ##' @param test_label The column of class to classify in the test data
-##' @param num_tree_range The range of the number of trees for forest. Default is c(1L, 1000L)
-##' @param mtry_range Value of mtry used
+##' @param num_tree_range The range of the number of trees for forest. Defaults
+##'   to 500 (no optimization).
+##' @param mtry_range Value of mtry used. Defaults from 1 to number of columns.
+##' @param min_node_size_range The range of minimum node sizes to best tested.
+##'   Default min is 1 and max is sqrt(nrow(train_data)).
 ##' @param init_points Number of randomly chosen points to sample the
 ##'   target function before Bayesian Optimization fitting the Gaussian Process.
 ##' @param n_iter Total number of times the Bayesian Optimization is to repeated.
@@ -39,8 +42,9 @@ rf_opt <- function(train_data,
                    train_label,
                    test_data,
                    test_label,
-                   num_tree_range = c(1L, 1000L),
-                   mtry_range,
+                   num_tree_range = 500L,
+                   mtry_range = c(1L, ncol(train_data)),
+                   min_node_size_range = c(1L, as.integer(sqrt(nrow(train_data)))),
                    init_points = 20,
                    n_iter = 1,
                    acq = "ei",
@@ -67,16 +71,32 @@ rf_opt <- function(train_data,
   # so we explicitly add to dataframe with a unique name to avoid conflicts.
   dtrain <- cbind(`_Y` = trainlabel, dtrain)
 
-  rf_holdout <- function(num_trees_opt, mtry_opt) {
-    model <- ranger(`_Y` ~., dtrain, num.trees = num_trees_opt, mtry = mtry_opt)
+  rf_holdout <- function(mtry_opt, min_node_size, num_trees = NULL) {
+    if (is.null(num_trees)) {
+      # Get num_trees default from the calling function.
+      #num_trees = get("num_tree_range", envir = parent.frame())
+      num_trees = num_tree_range
+    }
+    model <- ranger(`_Y` ~., dtrain,
+                    num.trees = num_trees,
+                    min.node.size = min_node_size,
+                    mtry = mtry_opt)
     t.pred <- predict(model, dat = dtest)
     Pred <- sum(diag(table(testlabel, t.pred$predictions)))/nrow(dtest)
     list(Score = Pred, Pred = Pred)
   }
 
+  bounds = list(mtry_opt = mtry_range,
+                min_node_size = min_node_size_range)
+
+  # Only add to bounds if we are optimizing over num_trees. If it's a single
+  # value just pass into ranger() and don't optimize it.
+  if (length(num_tree_range) != 1L) {
+    bounds[["num_trees"]] <- num_tree_range
+  }
+
   opt_res <- BayesianOptimization(rf_holdout,
-                                  bounds = list(num_trees_opt = num_tree_range,
-                                                mtry_opt = mtry_range),
+                                  bounds = bounds,
                                   init_points,
                                   init_grid_dt = NULL,
                                   n_iter,

--- a/R/rf_opt.R
+++ b/R/rf_opt.R
@@ -46,23 +46,29 @@ rf_opt <- function(train_data,
                    acq = "ei",
                    kappa = 2.576,
                    eps = 0.0,
-                   kernel = list(type = "exponential", power = 2))
-{
+                   kernel = list(type = "exponential", power = 2)) {
+
   dtrain <- train_data
   dtest <- test_data
 
-  if (class(train_label) != "factor"){
+  if (class(train_label) != "factor") {
     trainlabel <- as.factor(train_label)
-  } else{
-    trainlabel <- train_label}
+  } else {
+    trainlabel <- train_label
+  }
 
-  if (class(test_label) != "factor"){
+  if (class(test_label) != "factor") {
     testlabel <- as.factor(train_label)
-  } else{
-    testlabel <- test_label}
+  } else {
+    testlabel <- test_label
+  }
+
+  # Ranger does not seem to support Y being a vector outside of the dataframe,
+  # so we explicitly add to dataframe with a unique name to avoid conflicts.
+  dtrain <- cbind(`_Y` = trainlabel, dtrain)
 
   rf_holdout <- function(num_trees_opt, mtry_opt) {
-    model <- ranger(trainlabel ~., dtrain, num.trees = num_trees_opt, mtry = mtry_opt)
+    model <- ranger(`_Y` ~., dtrain, num.trees = num_trees_opt, mtry = mtry_opt)
     t.pred <- predict(model, dat = dtest)
     Pred <- sum(diag(table(testlabel, t.pred$predictions)))/nrow(dtest)
     list(Score = Pred, Pred = Pred)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(MlBayesOpt)
+
+test_check("MlBayesOpt")

--- a/tests/testthat/test-rf_opt.R
+++ b/tests/testthat/test-rf_opt.R
@@ -1,0 +1,70 @@
+library(MlBayesOpt)
+library(testthat)
+
+context("rf_opt")
+
+set.seed(123)
+
+# Default example.
+# This will generate an error in GP_deviance()
+# "Infinite values of the Deviance Function, unable to find optimum parameters"
+mod <- rf_opt(
+  train_data = iris_train,
+  train_label = iris_train$Species,
+  test_data = iris_test,
+  test_label = iris_test$Species,
+  mtry_range = c(1L, 4L)
+)
+
+print(mod)
+
+########################################3
+# Boston test.
+data(Boston, package = "MASS")
+
+dim(Boston)
+
+# Divide into training, test, and holdout.
+# 50% into training, 20% into test, 30% into holdout.
+n = nrow(Boston)
+n_training = ceiling(n * 0.5)
+n_test = ceiling(n * 0.2)
+n_holdout = n - n_training - n_test
+c(n_training, n_test, n_holdout)
+
+# Create assignment pool.
+pool = c(rep(1, n_training), rep(2, n_test), rep(3, n_holdout))
+
+# Randomize.
+set.seed(1, "L'Ecuyer-CMRG")
+assignment = sample(pool)
+
+#y = Boston$medv
+y_bin = as.factor(Boston$medv > 23)
+y_gaus = Boston$medv
+y = y_bin
+
+# Remove outcome from covariate dataframe.
+x = Boston[, -14]
+# Convert to a matrix and remove intercept.
+x_mat = data.frame(model.matrix(~ ., data = x)[, -1])
+
+x_train = x_mat[pool == 1, ]
+x_test = x_mat[pool == 2, ]
+x_holdout = x_mat[pool == 3, ]
+
+y_train = y[pool == 1]
+y_test = y[pool == 2]
+y_holdout = y[pool == 3]
+
+set.seed(71)
+res1 <- rf_opt(train_data = x_train,
+               train_label = y_train,
+               test_data = x_test,
+               test_label = y_test,
+               mtry_range = c(1L, ncol(x_train)),
+               # Doesn't work:
+               #num_tree_range = c(500L, 500L)
+               num_tree_range = c(500L, 501L)
+)
+str(res1)

--- a/tests/testthat/test-rf_opt.R
+++ b/tests/testthat/test-rf_opt.R
@@ -63,8 +63,7 @@ res1 <- rf_opt(train_data = x_train,
                test_data = x_test,
                test_label = y_test,
                mtry_range = c(1L, ncol(x_train)),
-               # Doesn't work:
-               #num_tree_range = c(500L, 500L)
-               num_tree_range = c(500L, 501L)
+               num_tree_range = 500L
 )
 str(res1)
+


### PR DESCRIPTION
Hi,

This adds support for optimizing over the min_node_size hyperparameter for random forest, and also supports not optimizing over num_trees (now defaults to 500) - per #36. Dependent upon my other pull request.

Thanks,
Chris