### PR TITLE
Added the ability to set the number of threads xgboost should use

### DIFF
--- a/R/xgb_cv_opt.R
+++ b/R/xgb_cv_opt.R
@@ -43,6 +43,7 @@
 ##'   that specifies the type of correlation function along with the smoothness parameter. Popular choices are square exponential (default) or matern 5/2
 ##' @param classes set the number of classes. To use only with multiclass objectives.
 ##' @param seed set seed.(default is 0)
+##' @param nthread set the number number of threads xgboost should use. Default: 1
 ##'
 ##' @return The score you specified in the evalmetric option and a list of Bayesian Optimization result is returned:
 ##' \itemize{
@@ -88,7 +89,8 @@ xgb_cv_opt <- function(data,
                        eps = 0.0,
                        optkernel = list(type = "exponential", power = 2),
                        classes = NULL,
-                       seed = 0
+                       seed = 0,
+                       nthread = 1
 )
 {
   if(class(data)[1] == "dgCMatrix")
@@ -133,7 +135,7 @@ xgb_cv_opt <- function(data,
       eval_met <- evalmetric
 
       cv <- xgb.cv(params = list(booster = "gbtree",
-                                 nthread = 1,
+                                 nthread = nthread,
                                  objective = object_fun,
                                  eval_metric = eval_met,
                                  eta = eta_opt,
@@ -171,7 +173,7 @@ xgb_cv_opt <- function(data,
       num_classes <- classes
 
       cv <- xgb.cv(params = list(booster = "gbtree",
-                                 nthread = 1,
+                                 nthread = nthread,
                                  objective = object_fun,
                                  num_class = num_classes,
                                  eval_metric = eval_met,

--- a/R/xgb_opt.R
+++ b/R/xgb_opt.R
@@ -44,6 +44,7 @@
 ##' @param optkernel Kernel (aka correlation function) for the underlying Gaussian Process. This parameter should be a list
 ##'   that specifies the type of correlation function along with the smoothness parameter. Popular choices are square exponential (default) or matern 5/2
 ##' @param classes set the number of classes. To use only with multiclass objectives.
+##' @param nthread set the number number of threads xgboost should use. Default: 1
 ##'
 ##' @return The test accuracy and a list of Bayesian Optimization result is returned:
 ##' \itemize{
@@ -93,7 +94,8 @@ xgb_opt <- function(train_data,
                     kappa = 2.576,
                     eps = 0.0,
                     optkernel = list(type = "exponential", power = 2),
-                    classes = NULL
+                    classes = NULL,
+                    nthread = 1
 )
 {
 
@@ -134,7 +136,7 @@ xgb_opt <- function(train_data,
 
       model <- xgb.train(params = list(objective = object_fun,
                                        eval_metric = eval_met,
-                                       nthread = 1,
+                                       nthread = nthread,
                                        eta = eta_opt,
                                        max_depth = max_depth_opt,
                                        subsample = subsample_opt,
@@ -162,7 +164,7 @@ xgb_opt <- function(train_data,
 
       model <- xgb.train(params = list(objective = object_fun,
                                        num_class = num_classes,
-                                       nthread = 1,
+                                       nthread = nthread,
                                        eval_metric = eval_met,
                                        eta = eta_opt,
                                        max_depth = max_depth_opt,

--- a/man/xgb_cv_opt.Rd
+++ b/man/xgb_cv_opt.Rd
@@ -9,7 +9,7 @@ xgb_cv_opt(data, label, objectfun, evalmetric, n_folds, eta_range = c(0.1,
   subsample_range = c(0.1, 1L), bytree_range = c(0.4, 1L),
   init_points = 4, n_iter = 10, acq = "ei", kappa = 2.576, eps = 0,
   optkernel = list(type = "exponential", power = 2), classes = NULL,
-  seed = 0)
+  seed = 0, nthread = 1)
 }
 \arguments{
 \item{data}{data}
@@ -71,6 +71,8 @@ that specifies the type of correlation function along with the smoothness parame
 \item{classes}{set the number of classes. To use only with multiclass objectives.}
 
 \item{seed}{set seed.(default is 0)}
+
+\item{nthread}{set the number number of threads xgboost should use. Default: 1}
 }
 \value{
 The score you specified in the evalmetric option and a list of Bayesian Optimization result is returned:

--- a/man/xgb_opt.Rd
+++ b/man/xgb_opt.Rd
@@ -9,7 +9,7 @@ xgb_opt(train_data, train_label, test_data, test_label, objectfun, evalmetric,
   nrounds_range = c(70, 160L), subsample_range = c(0.1, 1L),
   bytree_range = c(0.4, 1L), init_points = 4, n_iter = 10, acq = "ei",
   kappa = 2.576, eps = 0, optkernel = list(type = "exponential", power =
-  2), classes = NULL)
+  2), classes = NULL, nthread = 1)
 }
 \arguments{
 \item{train_data}{A data frame for training of xgboost}
@@ -72,6 +72,8 @@ increasing epsilon will make the optimized hyperparameters are more spread out a
 that specifies the type of correlation function along with the smoothness parameter. Popular choices are square exponential (default) or matern 5/2}
 
 \item{classes}{set the number of classes. To use only with multiclass objectives.}
+
+\item{nthread}{set the number number of threads xgboost should use. Default: 1}
 }
 \value{
 The test accuracy and a list of Bayesian Optimization result is returned:


### PR DESCRIPTION
Added the ability to set the number of threads xgboost should use to reduce runtimes. It Defaults to 1 to maintain the current code behaviour. 