### PR TITLE
Fix package name in installation instructions

### DIFF
--- a/vignettes/MlBayesOpt.Rmd
+++ b/vignettes/MlBayesOpt.Rmd
@@ -104,7 +104,7 @@ res0 <- xgb_cv_opt(data = fashion,
 ## Installation
 You can install **MlBayesOpt** from CRAN:
 ```{r cran-installation, eval = FALSE}
-install.packages("MlbayesOpt")
+install.packages("MlBayesOpt")
 ```
 
 You can install MlBayesOpt (latest dev version) from github with:


### PR DESCRIPTION
This is a super tiny fix. I copy/pasted the `install.packages` command from the vignette into my R session and realized the package name has the wrong capitalization.

Thanks so much for this package!